### PR TITLE
Add CSRF_WHITELIST

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV GEOSERVER_VERSION=2.15.x
 ENV GEOSERVER_DATA_DIR="/geoserver_data/data"
 ENV GEOSERVER_BACKUP_DIR="/geoserver_data/backup"
 ENV GEOSERVER_BASE_DIR="/geoserver_data"
+ENV GEOSERVER_CSRF_WHITELIST="geo.solspec.io"
 # Download and install GeoServer
 #
 RUN cd /usr/local/tomcat/webapps \


### PR DESCRIPTION
Designate a CSRF Whitelist to prevent 403 "Origin does not correspond to request" Errors from Geoserver and embedded Wicket logic.